### PR TITLE
fix(export): fix exporting more than 20 customers with predicate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage
 config.js
 exports
 sftp-credentials.json
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ config.js
 exports
 sftp-credentials.json
 .idea
+tmp

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sphere-customer-export",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -915,9 +915,9 @@
       "integrity": "sha512-ETG8JGG0xOt2f1JzxrAcQONVc4+7srUdXeyLnow60ntBr+qiNCFTqi+ME6g0vZ4hMCbrwNrDPJPOYVznAeDDHQ=="
     },
     "csv-parse": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-2.5.0.tgz",
-      "integrity": "sha512-4OcjOJQByI0YDU5COYw9HAqjo8/MOLLmT9EKyMCXUzgvh30vS1SlMK+Ho84IH5exN44cSnrYecw/7Zpu2m4lkA=="
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.4.1.tgz",
+      "integrity": "sha512-uFe5phPfmwBXSPWz5GYHeaEc2Oezn2kY5iLIvG1sJjc32Y4GU7T/b/uX5ffZh4CBDWwJQjwAuxrDEdl3Z5Qv+g=="
     },
     "csv-stringify": {
       "version": "2.1.0",
@@ -4108,6 +4108,13 @@
             "csv-parse": "^2.0.0",
             "csv-stringify": "^2.0.0",
             "stream-transform": "^1.0.0"
+          },
+          "dependencies": {
+            "csv-parse": {
+              "version": "2.5.0",
+              "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-2.5.0.tgz",
+              "integrity": "sha512-4OcjOJQByI0YDU5COYw9HAqjo8/MOLLmT9EKyMCXUzgvh30vS1SlMK+Ho84IH5exN44cSnrYecw/7Zpu2m4lkA=="
+            }
           }
         },
         "debug": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,9 @@
       "dev": true
     },
     "ajv": {
-      "version": "6.5.5",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
-      "integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+      "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -118,7 +118,7 @@
     },
     "ansi-colors": {
       "version": "0.2.0",
-      "resolved": "http://registry.npmjs.org/ansi-colors/-/ansi-colors-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-0.2.0.tgz",
       "integrity": "sha1-csMd4qDZoszQysMMyYI+6y9kNLU=",
       "requires": {
         "ansi-bgblack": "^0.1.1",
@@ -232,7 +232,7 @@
     },
     "ansi-regex": {
       "version": "0.2.1",
-      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
       "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk="
     },
     "ansi-reset": {
@@ -631,7 +631,7 @@
     },
     "chalk": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
       "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
       "requires": {
         "ansi-styles": "^1.1.0",
@@ -713,7 +713,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -735,7 +735,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -788,9 +788,9 @@
       "dev": true
     },
     "combined-stream": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
-      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -803,9 +803,9 @@
       "optional": true
     },
     "component-emitter": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -843,28 +843,6 @@
         "request": "^2.86.0"
       },
       "dependencies": {
-        "esprima": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-          "dev": true
-        },
-        "growl": {
-          "version": "1.10.5",
-          "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-          "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
-          "dev": true
-        },
-        "js-yaml": {
-          "version": "3.13.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-          "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-          "dev": true,
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          }
-        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
@@ -882,37 +860,12 @@
         "csv-parse": "^4.3.0",
         "csv-stringify": "^5.1.2",
         "stream-transform": "^1.0.8"
-      },
-      "dependencies": {
-        "csv-generate": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-3.2.0.tgz",
-          "integrity": "sha512-ZdS2KrgoLxm1guL9XhuaZX223Tiorldvl9QC0M/gihcrJavNDokAp/rX3CyyRHpK+rImxEE3L47cHe7npQMkkg=="
-        },
-        "csv-parse": {
-          "version": "4.4.1",
-          "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.4.1.tgz",
-          "integrity": "sha512-uFe5phPfmwBXSPWz5GYHeaEc2Oezn2kY5iLIvG1sJjc32Y4GU7T/b/uX5ffZh4CBDWwJQjwAuxrDEdl3Z5Qv+g=="
-        },
-        "csv-stringify": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-5.3.0.tgz",
-          "integrity": "sha512-VMYPbE8zWz475smwqb9VbX9cj0y4J0PBl59UdcqzLkzXHZZ8dh4Rmbb0ZywsWEtUml4A96Hn7Q5MW9ppVghYzg==",
-          "requires": {
-            "lodash.get": "~4.4.2"
-          }
-        },
-        "stream-transform": {
-          "version": "1.0.8",
-          "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-1.0.8.tgz",
-          "integrity": "sha512-1q+dL790Ps0NV33rISMq9OLtfDA9KMJZdo1PHZXE85orrWsM4FAh8CVyAOTHO0rhyeM138KNPngBPrx33bFsxw=="
-        }
       }
     },
     "csv-generate": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-2.2.2.tgz",
-      "integrity": "sha512-ETG8JGG0xOt2f1JzxrAcQONVc4+7srUdXeyLnow60ntBr+qiNCFTqi+ME6g0vZ4hMCbrwNrDPJPOYVznAeDDHQ=="
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-3.2.3.tgz",
+      "integrity": "sha512-IcR3K0Nx+nJAkcU2eAglVR7DuHnxcuhUM2w2cR+aHOW7bZp2S5LyN2HF3zTkp6BV/DjR6ykoKznUm+AjnWcOKg=="
     },
     "csv-parse": {
       "version": "4.4.1",
@@ -920,9 +873,9 @@
       "integrity": "sha512-uFe5phPfmwBXSPWz5GYHeaEc2Oezn2kY5iLIvG1sJjc32Y4GU7T/b/uX5ffZh4CBDWwJQjwAuxrDEdl3Z5Qv+g=="
     },
     "csv-stringify": {
-      "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/csv-stringify/-/csv-stringify-2.1.0.tgz",
-      "integrity": "sha512-wEmZksjlGEZEP0Ai7eyCQuVd68CUqP1TmQ7ay4bchtxTY37tAm1DgM1xPj2L9isEylGEmvfFwA6RXwnqLzKfuA==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-5.3.0.tgz",
+      "integrity": "sha512-VMYPbE8zWz475smwqb9VbX9cj0y4J0PBl59UdcqzLkzXHZZ8dh4Rmbb0ZywsWEtUml4A96Hn7Q5MW9ppVghYzg==",
       "requires": {
         "lodash.get": "~4.4.2"
       }
@@ -1084,6 +1037,12 @@
         "source-map": "~0.2.0"
       },
       "dependencies": {
+        "esprima": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+          "dev": true
+        },
         "source-map": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
@@ -1097,9 +1056,9 @@
       }
     },
     "esprima": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
     "estraverse": {
@@ -1116,7 +1075,7 @@
     },
     "eventemitter2": {
       "version": "0.4.14",
-      "resolved": "http://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
       "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
       "dev": true
     },
@@ -1471,7 +1430,7 @@
     },
     "git-config-path": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/git-config-path/-/git-config-path-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/git-config-path/-/git-config-path-1.0.1.tgz",
       "integrity": "sha1-bTP37WPbDQ4RgTFQO6s6ykfVRmQ=",
       "requires": {
         "extend-shallow": "^2.0.1",
@@ -1481,7 +1440,7 @@
     },
     "git-repo-name": {
       "version": "0.6.0",
-      "resolved": "http://registry.npmjs.org/git-repo-name/-/git-repo-name-0.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/git-repo-name/-/git-repo-name-0.6.0.tgz",
       "integrity": "sha1-rwmIRlaqU37GJccIcAgXXNYSKP8=",
       "requires": {
         "cwd": "^0.9.1",
@@ -1594,25 +1553,10 @@
         "rimraf": "~2.6.2"
       },
       "dependencies": {
-        "argparse": {
-          "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-          "dev": true,
-          "requires": {
-            "sprintf-js": "~1.0.2"
-          }
-        },
         "coffeescript": {
           "version": "1.10.0",
           "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-1.10.0.tgz",
           "integrity": "sha1-56qDAZF+9iGzXYo580jc3R234z4=",
-          "dev": true
-        },
-        "esprima": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
           "dev": true
         },
         "glob": {
@@ -1639,16 +1583,6 @@
             "grunt-known-options": "~1.1.0",
             "nopt": "~3.0.6",
             "resolve": "~1.1.0"
-          }
-        },
-        "js-yaml": {
-          "version": "3.13.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-          "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-          "dev": true,
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
           }
         },
         "resolve": {
@@ -1681,12 +1615,6 @@
               }
             }
           }
-        },
-        "sprintf-js": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-          "dev": true
         }
       }
     },
@@ -1851,12 +1779,6 @@
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.3.0"
           }
-        },
-        "coffeescript": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-2.4.1.tgz",
-          "integrity": "sha512-34GV1aHrsMpTaO3KfMJL40ZNuvKDR/g98THHnE9bQj8HjMaZvSrLik99WWqyMhRtbe8V5hpx5iLgdcSvM/S2wg==",
-          "dev": true
         },
         "supports-color": {
           "version": "5.5.0",
@@ -2025,14 +1947,6 @@
         "lodash": "~4.17.10",
         "underscore.string": "~3.3.4",
         "which": "~1.3.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true
-        }
       }
     },
     "grunt-shell": {
@@ -2178,9 +2092,9 @@
       "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
     },
     "homedir-polyfill": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
-      "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+      "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
       "requires": {
         "parse-passwd": "^1.0.0"
       }
@@ -2451,6 +2365,12 @@
           "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
           "dev": true
         },
+        "esprima": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+          "dev": true
+        },
         "glob": {
           "version": "5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
@@ -2525,7 +2445,7 @@
         },
         "mkdirp": {
           "version": "0.3.5",
-          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
           "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc=",
           "dev": true
         }
@@ -2542,20 +2462,20 @@
       "dependencies": {
         "mkdirp": {
           "version": "0.3.5",
-          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
           "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc=",
           "dev": true
         }
       }
     },
     "js-yaml": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
-      "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
-        "esprima": "^2.6.0"
+        "esprima": "^4.0.0"
       }
     },
     "jsbn": {
@@ -2756,6 +2676,11 @@
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
+    "lodash.isnil": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isnil/-/lodash.isnil-4.0.0.tgz",
+      "integrity": "sha1-SeKM1VkBNFjIFMVHnTxmOiG/qmw="
+    },
     "log-driver": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
@@ -2773,7 +2698,7 @@
     },
     "log-utils": {
       "version": "0.2.1",
-      "resolved": "http://registry.npmjs.org/log-utils/-/log-utils-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/log-utils/-/log-utils-0.2.1.tgz",
       "integrity": "sha1-pMIXoN2aUFFdm5ICBgkas9TgMc8=",
       "requires": {
         "ansi-colors": "^0.2.0",
@@ -2979,16 +2904,16 @@
       }
     },
     "mime-db": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
-      "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg=="
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
     },
     "mime-types": {
-      "version": "2.1.21",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
-      "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+      "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
       "requires": {
-        "mime-db": "~1.37.0"
+        "mime-db": "1.40.0"
       }
     },
     "minimatch": {
@@ -3001,7 +2926,7 @@
     },
     "minimist": {
       "version": "0.0.10",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
       "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
     },
     "mixin-deep": {
@@ -3025,7 +2950,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -3033,15 +2958,15 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
     },
     "moment": {
-      "version": "2.22.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
-      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=",
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
       "optional": true
     },
     "ms": {
@@ -3061,9 +2986,9 @@
       }
     },
     "nan": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-      "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
       "optional": true
     },
     "nanomatch": {
@@ -3159,14 +3084,14 @@
     },
     "ncp": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
       "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
       "optional": true
     },
     "neo-async": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
-      "integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
+      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
       "dev": true
     },
     "nopt": {
@@ -3188,17 +3113,6 @@
         "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
-      },
-      "dependencies": {
-        "resolve": {
-          "version": "1.10.1",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.1.tgz",
-          "integrity": "sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==",
-          "dev": true,
-          "requires": {
-            "path-parse": "^1.0.6"
-          }
-        }
       }
     },
     "normalize-pkg": {
@@ -3228,7 +3142,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
@@ -3400,7 +3314,7 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-tmpdir": {
@@ -3481,7 +3395,7 @@
     },
     "parse-git-config": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/parse-git-config/-/parse-git-config-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/parse-git-config/-/parse-git-config-1.1.1.tgz",
       "integrity": "sha1-06mYQxcTL1c5hxK7pDjhKVkN34w=",
       "requires": {
         "extend-shallow": "^2.0.1",
@@ -3526,7 +3440,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
@@ -3616,15 +3530,15 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
     },
     "psl": {
-      "version": "1.1.29",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
+      "version": "1.1.32",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.32.tgz",
+      "integrity": "sha512-MHACAkHpihU/REGGPLj4sEfc/XKW2bheigvHO1dUqjaKigMp1C8+WLQYRGgeKFMsw5PMfegZcaN8IDXK/cD0+g=="
     },
     "punycode": {
       "version": "2.1.1",
@@ -3811,11 +3725,11 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-      "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.0.tgz",
+      "integrity": "sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==",
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "^1.0.6"
       }
     },
     "resolve-dir": {
@@ -3841,7 +3755,7 @@
     },
     "rimraf": {
       "version": "2.4.5",
-      "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
       "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
       "optional": true,
       "requires": {
@@ -3885,9 +3799,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
     },
     "set-getter": {
       "version": "0.1.0",
@@ -4067,12 +3981,13 @@
       "dev": true
     },
     "sphere-node-sdk": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/sphere-node-sdk/-/sphere-node-sdk-2.1.2.tgz",
-      "integrity": "sha512-MlvET7lwAwWffW1dOsoII1u+89kozOuNefBrZAB4/gZqGL7RxLXiWb5RVZ0czo97AbZxJVDMyvIOdkY7rxoolA==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/sphere-node-sdk/-/sphere-node-sdk-2.4.1.tgz",
+      "integrity": "sha512-c4hSCddRu6TfbHVc1RJviLoBMrAe11wSsWmPb9OXU7qKQpQIFGc6iMLNWf7ZxGWzZvVm3hRa3ikjO82AIYg+RA==",
       "requires": {
         "debug": "2.6.9",
         "jsondiffpatch": "0.2.4",
+        "lodash.isnil": "^4.0.0",
         "request": "^2.88.0",
         "sphere-node-utils": "^1.0.0",
         "underscore-mixins": "^0.1.4"
@@ -4108,13 +4023,24 @@
             "csv-parse": "^2.0.0",
             "csv-stringify": "^2.0.0",
             "stream-transform": "^1.0.0"
-          },
-          "dependencies": {
-            "csv-parse": {
-              "version": "2.5.0",
-              "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-2.5.0.tgz",
-              "integrity": "sha512-4OcjOJQByI0YDU5COYw9HAqjo8/MOLLmT9EKyMCXUzgvh30vS1SlMK+Ho84IH5exN44cSnrYecw/7Zpu2m4lkA=="
-            }
+          }
+        },
+        "csv-generate": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-2.2.2.tgz",
+          "integrity": "sha512-ETG8JGG0xOt2f1JzxrAcQONVc4+7srUdXeyLnow60ntBr+qiNCFTqi+ME6g0vZ4hMCbrwNrDPJPOYVznAeDDHQ=="
+        },
+        "csv-parse": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-2.5.0.tgz",
+          "integrity": "sha512-4OcjOJQByI0YDU5COYw9HAqjo8/MOLLmT9EKyMCXUzgvh30vS1SlMK+Ho84IH5exN44cSnrYecw/7Zpu2m4lkA=="
+        },
+        "csv-stringify": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-2.1.0.tgz",
+          "integrity": "sha512-wEmZksjlGEZEP0Ai7eyCQuVd68CUqP1TmQ7ay4bchtxTY37tAm1DgM1xPj2L9isEylGEmvfFwA6RXwnqLzKfuA==",
+          "requires": {
+            "lodash.get": "~4.4.2"
           }
         },
         "debug": {
@@ -4163,9 +4089,9 @@
       }
     },
     "sprintf-js": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
-      "integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
     },
     "ssh2": {
       "version": "0.5.5",
@@ -4186,9 +4112,9 @@
       }
     },
     "sshpk": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
-      "integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -4212,9 +4138,9 @@
       }
     },
     "stream-transform": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-1.0.7.tgz",
-      "integrity": "sha512-bp27sM5lf75yOZAM0HfKgN7jub2FApKmXUVYnN/zuw4raqtinM3muxzd+ny262opnKvAg5PnMO66N4Eq928ayw=="
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-1.0.8.tgz",
+      "integrity": "sha512-1q+dL790Ps0NV33rISMq9OLtfDA9KMJZdo1PHZXE85orrWsM4FAh8CVyAOTHO0rhyeM138KNPngBPrx33bFsxw=="
     },
     "streamsearch": {
       "version": "0.1.2",
@@ -4240,7 +4166,7 @@
     },
     "strip-ansi": {
       "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
       "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
       "requires": {
         "ansi-regex": "^0.2.1"
@@ -4494,9 +4420,9 @@
       }
     },
     "uglify-js": {
-      "version": "3.5.11",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.11.tgz",
-      "integrity": "sha512-izPJg8RsSyqxbdnqX36ExpbH3K7tDBsAU/VfNv89VkMFy3z39zFjunQGsSHOlGlyIfGLGprGeosgQno3bo2/Kg==",
+      "version": "3.5.15",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.15.tgz",
+      "integrity": "sha512-fe7aYFotptIddkwcm6YuA0HmknBZ52ZzOsUxZEdhhkSsz7RfjHDX2QDxwKTiv4JQ5t5NhfmpgAK+J7LiDhKSqg==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -4530,7 +4456,7 @@
     },
     "underscore.string": {
       "version": "3.3.4",
-      "resolved": "http://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
       "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
       "requires": {
         "sprintf-js": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "dependencies": {
     "bluebird": "3.5.4",
     "csv": "5.1.1",
+    "csv-parse": "4.4.1",
     "optimist": "0.6.1",
     "safe-access": "0.1.0",
     "sphere-node-sdk": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
   "dependencies": {
     "bluebird": "3.5.4",
     "csv": "5.1.1",
-    "csv-parse": "4.4.1",
     "optimist": "0.6.1",
     "safe-access": "0.1.0",
     "sphere-node-sdk": "^2.1.2",

--- a/src/coffee/customerexport.coffee
+++ b/src/coffee/customerexport.coffee
@@ -22,16 +22,21 @@ class CustomerExport
     .then (content) => @csvMapping.mapCustomers content, customers
 
   _fetchCustomers: ->
-    if @_exportOptions.where
-      @client.customers.where(@_exportOptions.where)
-    else
-      @client.customers.all()
+    customersQuery = @client.customers
+    customersQuery.perPage(200)
+    allCustomers = []
 
-    @client.customers
-    .expand('customerGroup')
-    .fetch()
-    .then (result) ->
-      allCustomers = result.body.results
-      Promise.resolve allCustomers
+    if @_exportOptions.where
+      customersQuery.where(@_exportOptions.where)
+
+
+    customersQuery
+      .expand('customerGroup')
+      .process (result) ->
+        allCustomers = allCustomers.concat(result.body.results)
+        Promise.resolve()
+      .then ->
+        Promise.resolve allCustomers
+
 
 module.exports = CustomerExport

--- a/src/coffee/customerexport.coffee
+++ b/src/coffee/customerexport.coffee
@@ -24,19 +24,15 @@ class CustomerExport
   _fetchCustomers: ->
     customersQuery = @client.customers
     customersQuery.perPage(200)
-    allCustomers = []
 
     if @_exportOptions.where
       customersQuery.where(@_exportOptions.where)
 
-
     customersQuery
       .expand('customerGroup')
       .process (result) ->
-        allCustomers = allCustomers.concat(result.body.results)
-        Promise.resolve()
-      .then ->
-        Promise.resolve allCustomers
+        Promise.resolve(result.body.results)
+      , { accumulate: true }
 
 
 module.exports = CustomerExport

--- a/src/coffee/mapping-utils/csv.coffee
+++ b/src/coffee/mapping-utils/csv.coffee
@@ -1,6 +1,7 @@
 _ = require 'underscore'
 Promise = require 'bluebird'
 Csv = require 'csv'
+csvParse = require 'csv-parse'
 access = require 'safe-access'
 
 class CsvMapping
@@ -64,11 +65,14 @@ class CsvMapping
 
   parse: (csvString) ->
     new Promise (resolve, reject) ->
-      Csv.parse(csvString)
-      .on 'error', (error) -> reject error
-      .on 'readable', () ->
-        data = @read()
-        resolve data
+      csvParse csvString, (err, output) ->
+        if err
+          reject(err)
+
+        if output.length == 0
+          reject(new Error('Template CSV has to have at least one CSV line'))
+
+        resolve(output[0])
 
   toCSV: (header, data) ->
     new Promise (resolve, reject) ->

--- a/src/coffee/mapping-utils/csv.coffee
+++ b/src/coffee/mapping-utils/csv.coffee
@@ -1,7 +1,6 @@
 _ = require 'underscore'
 Promise = require 'bluebird'
 Csv = require 'csv'
-csvParse = require 'csv-parse'
 access = require 'safe-access'
 
 class CsvMapping
@@ -65,7 +64,7 @@ class CsvMapping
 
   parse: (csvString) ->
     new Promise (resolve, reject) ->
-      csvParse csvString, (err, output) ->
+      Csv.parse csvString, (err, output) ->
         if err
           reject(err)
 

--- a/src/coffee/run.coffee
+++ b/src/coffee/run.coffee
@@ -128,6 +128,7 @@ ensureCredentials(argv)
       fileName = "customers_#{ts}.csv"
     else
       fileName = 'customers.csv'
+
     csvFile = "#{@outputDir}/#{fileName}"
     logger.info "Storing CSV export to '#{csvFile}'."
     fs.writeFileAsync csvFile, data

--- a/src/spec/customerexport.spec.coffee
+++ b/src/spec/customerexport.spec.coffee
@@ -23,14 +23,16 @@ describe 'CustomerExport', ->
     expect(csvExport).toThrow(new Error 'You need to provide a csv template for exporting customer information')
 
   it '#_fetchCustomers (all)', (done) ->
-    spyOn(@customerExport.client.customers, 'all')
-    spyOn(@customerExport.client.customers, 'fetch').andCallFake -> Promise.resolve
-      body:
-        results: [1, 2]
+    spyOn(@customerExport.client.customers, 'process')
+      .andCallFake (processFn) ->
+        processFn
+          body:
+            results: [1, 2]
+        Promise.resolve()
+
     @customerExport._fetchCustomers()
     .then (customers) =>
       expect(customers).toEqual [1, 2]
-      expect(@customerExport.client.customers.all).toHaveBeenCalled()
       done()
     .catch (e) -> done e
 
@@ -47,9 +49,12 @@ describe 'CustomerExport', ->
     customerExport = new CustomerExport config
 
     spyOn(customerExport.client.customers, 'where')
-    spyOn(customerExport.client.customers, 'fetch').andCallFake -> Promise.resolve
-      body:
-        results: [1, 2]
+    spyOn(customerExport.client.customers, 'process')
+      .andCallFake (processFn) ->
+        processFn
+          body:
+            results: [1, 2]
+        Promise.resolve()
 
     customerExport._fetchCustomers()
     .then (customers) ->

--- a/src/spec/customerexport.spec.coffee
+++ b/src/spec/customerexport.spec.coffee
@@ -28,7 +28,7 @@ describe 'CustomerExport', ->
         processFn
           body:
             results: [1, 2]
-        Promise.resolve()
+        Promise.resolve([1, 2])
 
     @customerExport._fetchCustomers()
     .then (customers) =>
@@ -54,7 +54,7 @@ describe 'CustomerExport', ->
         processFn
           body:
             results: [1, 2]
-        Promise.resolve()
+        Promise.resolve([1, 2])
 
     customerExport._fetchCustomers()
     .then (customers) ->


### PR DESCRIPTION
This PR fixes exporting multiple customers when the predicate is given.

Originally [we used](https://github.com/sphereio/commercetools-customer-export/blob/master/src/coffee/customerexport.coffee#L26) `fetch()` method which by default loads only 20 records from API. We should use `process()` instead which iterates over all results matching given predicate.